### PR TITLE
May be a typo in caffe proto parameter name

### DIFF
--- a/sklearn_theano/feature_extraction/caffe/caffemodel.py
+++ b/sklearn_theano/feature_extraction/caffe/caffemodel.py
@@ -152,7 +152,10 @@ def _get_property(obj, property_path):
 def _parse_caffe_model(caffe_model):
 
     caffe_pb2 = _get_caffe_pb2()  # need to remove this dependence on pb here
-    _layer_types = caffe_pb2.V1LayerParameter.LayerType.items()
+    try:
+        _layer_types = caffe_pb2.LayerParameter.LayerType.items()
+    except AttributeError:
+        _layer_types = caffe_pb2.V1LayerParameter.LayerType.items()
 
     # create a dictionary that indexes both ways, number->name, name->number
     layer_types = dict(_layer_types)

--- a/sklearn_theano/feature_extraction/caffe/caffemodel.py
+++ b/sklearn_theano/feature_extraction/caffe/caffemodel.py
@@ -152,7 +152,7 @@ def _get_property(obj, property_path):
 def _parse_caffe_model(caffe_model):
 
     caffe_pb2 = _get_caffe_pb2()  # need to remove this dependence on pb here
-    _layer_types = caffe_pb2.LayerParameter.LayerType.items()
+    _layer_types = caffe_pb2.V1LayerParameter.LayerType.items()
 
     # create a dictionary that indexes both ways, number->name, name->number
     layer_types = dict(_layer_types)


### PR DESCRIPTION
After compiling the latest `caffe.proto` proto file using the protobuf compiler, a `caffe_pb2.py` file is created. 
Problem is there are no `LayerParameter.LayerType`s, but there are two appearances of `V1LayerParameter.LayerType`. 
I can confirm that after this change, code works as expected.