### PR TITLE
Added manifest to include examples in pip install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include *.rst
+recursive-include sklearn_theano *.json *.txt
+recursive-include sklearn_theano/datasets *.jpg *.png
+include LICENSE 
+include AUTHORS.rst
+include README.rst


### PR DESCRIPTION
This manifest should include all the .json and .jpg files we use.