### PR TITLE
Deprecate fancy_maxpool

### DIFF
--- a/sklearn_theano/base.py
+++ b/sklearn_theano/base.py
@@ -8,6 +8,9 @@ import numpy as np
 import theano.tensor as T
 from theano.tensor.signal.downsample import max_pool_2d
 
+from distutils.version import LooseVersion
+import warnings
+
 
 def _relu(x):
     return T.maximum(x, 0)
@@ -239,7 +242,7 @@ def _lcm(num1, num2):
     return num1 * num2 / _gcd(num1, num2)
 
 
-def fancy_max_pool(input_tensor, pool_shape, pool_stride,
+def fancy_max_pool_(input_tensor, pool_shape, pool_stride,
                     ignore_border=False):
     """Using theano built-in maxpooling, create a more flexible version.
 
@@ -286,6 +289,19 @@ def fancy_max_pool(input_tensor, pool_shape, pool_stride,
     return output.reshape(T.concatenate([pre_shape, output.shape[1:]]),
                           ndim=input_tensor.ndim)
 
+
+if LooseVersion(theano.__version__) < LooseVersion('0.7.0'):
+    warnings.warn(('Using theano 0.7.0 or later is recommended.'
+                   ' Current version is %s. Support for versions earlier'
+                   ' than 0.7.0 will be removed at first release.')
+                  % theano.__version__)
+    fancy_max_pool = fancy_max_pool_
+else:
+    def fancy_max_pool(input_tensor, pool_shape, pool_stride,
+                       ignore_border=False):
+        return T.signal.downsample.maxpool_2d(input_tensor, pool_shape,
+                                              ignore_border=ignore_border,
+                                              st=pool_stride)
 
 class FancyMaxPool(object):
     """Extended pooling functionality. Allows independent specification

--- a/sklearn_theano/base.py
+++ b/sklearn_theano/base.py
@@ -306,7 +306,9 @@ if LooseVersion(theano.__version__) < LooseVersion('0.7.0'):
 else:
     def fancy_max_pool(input_tensor, pool_shape, pool_stride,
                        ignore_border=False, padding=(0, 0)):
-        return T.signal.downsample.maxpool_2d(input_tensor, pool_shape,
+        if padding not in [0, (0, 0)]:
+            ignore_border = True
+        return T.signal.downsample.max_pool_2d(input_tensor, pool_shape,
                                               ignore_border=ignore_border,
                                               st=pool_stride,
                                               padding=padding)
@@ -383,9 +385,10 @@ class CaffePool(object):
         # Replicating caffe style pooling means zero padding
         # then strided pooling with ignore_border=True
         if self.pool_type == 'max':
-            pooled = fancy_max_pool(padded_input,
+            pooled = fancy_max_pool(self.input_,
                                     self.pool_shape, self.pool_stride,
-                                    ignore_border=False)
+                                    ignore_border=False,
+                                    padding=self.padding)
         elif self.pool_type == 'avg':
             if self.padding in [0, (0, 0)]:
                 padded_input = self.input_

--- a/sklearn_theano/base.py
+++ b/sklearn_theano/base.py
@@ -243,7 +243,7 @@ def _lcm(num1, num2):
 
 
 def fancy_max_pool_(input_tensor, pool_shape, pool_stride,
-                    ignore_border=False):
+                    ignore_border=False, padding=(0, 0)):
     """Using theano built-in maxpooling, create a more flexible version.
 
     Obviously suboptimal, but gets the work done."""
@@ -261,11 +261,18 @@ def fancy_max_pool_(input_tensor, pool_shape, pool_stride,
     lcmh, lcmw = [_lcm(p, s) for p, s in zip(pool_shape, pool_stride)]
     dsh, dsw = lcmh / pool_shape[0], lcmw / pool_shape[1]
 
-    pre_shape = input_tensor.shape[:-2]
+    if padding in [0, (0, 0)]:
+        padded_input = input_tensor
+    else:
+        zero_padder = ZeroPad(padding=padding)
+        zero_padder._build_expression(input_tensor)
+        padded_input = zero_padder.expression_
+
+    pre_shape = padded_input.shape[:-2]
     length = T.prod(pre_shape)
-    post_shape = input_tensor.shape[-2:]
+    post_shape = padded_input.shape[-2:]
     new_shape = T.concatenate([[length], post_shape])
-    reshaped_input = input_tensor.reshape(new_shape, ndim=3)
+    reshaped_input = padded_input.reshape(new_shape, ndim=3)
     sub_pools = []
     for sh in range(0, lcmh, pool_stride[0]):
         sub_pool = []
@@ -280,14 +287,14 @@ def fancy_max_pool_(input_tensor, pool_shape, pool_stride,
     output_shape = (length,
                     T.sum([l[0].shape[1] for l in sub_pools]),
                     T.sum([i.shape[2] for i in sub_pools[0]]))
-    output = T.zeros(output_shape, dtype=input_tensor.dtype)
+    output = T.zeros(output_shape, dtype=padded_input.dtype)
     for i, line in enumerate(sub_pools):
         for j, item in enumerate(line):
             output = T.set_subtensor(output[:, i::lcmh / pool_stride[0],
                                                j::lcmw / pool_stride[1]],
                                      item)
     return output.reshape(T.concatenate([pre_shape, output.shape[1:]]),
-                          ndim=input_tensor.ndim)
+                          ndim=padded_input.ndim)
 
 
 if LooseVersion(theano.__version__) < LooseVersion('0.7.0'):
@@ -298,10 +305,11 @@ if LooseVersion(theano.__version__) < LooseVersion('0.7.0'):
     fancy_max_pool = fancy_max_pool_
 else:
     def fancy_max_pool(input_tensor, pool_shape, pool_stride,
-                       ignore_border=False):
+                       ignore_border=False, padding=(0, 0)):
         return T.signal.downsample.maxpool_2d(input_tensor, pool_shape,
                                               ignore_border=ignore_border,
-                                              st=pool_stride)
+                                              st=pool_stride,
+                                              padding=padding)
 
 class FancyMaxPool(object):
     """Extended pooling functionality. Allows independent specification
@@ -374,17 +382,17 @@ class CaffePool(object):
 
         # Replicating caffe style pooling means zero padding
         # then strided pooling with ignore_border=True
-        if self.padding in [0, (0, 0)]:
-            padded_input = self.input_
-        else:
-            zero_padder = ZeroPad(padding=self.padding)
-            zero_padder._build_expression(self.input_)
-            padded_input = zero_padder.expression_
         if self.pool_type == 'max':
             pooled = fancy_max_pool(padded_input,
                                     self.pool_shape, self.pool_stride,
                                     ignore_border=False)
         elif self.pool_type == 'avg':
+            if self.padding in [0, (0, 0)]:
+                padded_input = self.input_
+            else:
+                zero_padder = ZeroPad(padding=self.padding)
+                zero_padder._build_expression(self.input_)
+                padded_input = zero_padder.expression_
             # self.pool_shape needs to be a tuple
             avg_kernel = T.cast(T.ones((1, 1) + self.pool_shape,
                                 dtype=self.input_.dtype

--- a/sklearn_theano/feature_extraction/caffe/tests/test_googlenet.py
+++ b/sklearn_theano/feature_extraction/caffe/tests/test_googlenet.py
@@ -1,8 +1,11 @@
 from skimage.data import coffee, camera
+from sklearn_theano.feature_extraction.caffe import googlenet
 from sklearn_theano.feature_extraction import (
     GoogLeNetTransformer, GoogLeNetClassifier)
 import numpy as np
+import theano
 from nose import SkipTest
+from numpy.testing import assert_array_almost_equal, assert_almost_equal
 import os
 
 co = coffee().astype(np.float32)
@@ -28,3 +31,45 @@ def test_googlenet_classifier():
 
     c.predict(co)
     c.predict(ca)
+
+
+def _fetch_caffe_layers_for_coffee():
+    """Loads a file containing all caffe layer outputs for
+    skimage.data.coffee."""
+
+    # TODO: write a generic pycaffe model finder
+    #       and feedforward any image or load from disk
+
+    f = np.load('coffee.npz')
+    output = dict()
+    for k in f.files:
+        output[k] = f[k]
+    return output
+
+
+def test_caffe_correspondence(verbose=1):
+    """Test correspondence of all layers to caffe model"""
+
+    c = _fetch_caffe_layers_for_coffee()
+
+    layer_expr, input_expr = googlenet.create_theano_expressions(
+        verbose=verbose)
+    layer_names = layer_expr.keys()
+
+    # restrict layers to those available in c
+    exclude = ['data']
+    layer_names = [name for name in layer_names if name in c.keys()
+                   and not name in exclude]
+
+    all_outputs = theano.function([input_expr],
+                                  [layer_expr[name] for name in layer_names])
+
+    fprop = all_outputs(c['data'][np.newaxis])
+
+    for i, name in enumerate(layer_names):
+        if verbose > 0:
+            print "Comparing %s" % name
+        assert_array_almost_equal(fprop[i][0], c[name], decimal=2)
+        assert_almost_equal(
+            ((fprop[i][0] - c[name]) ** 2).sum() / (c[name] ** 2).sum(), 0)
+


### PR DESCRIPTION
I have deprecated `fancy_maxpool` and if theano version >= 0.7 is detected, it will now use `T.signal.downsample.max_pool_2d` because it now features everything we need.

In order to automate correspondency testing and to ensure quality, I wrote an automatic test to check correspondence between all layers. I have added the image to test against in a commit. I am wondering whether this was wise or not: It is 40M large and maybe some people find repos of that size weird. This testing file can also be provided as a download. @kastnerkyle what do you think?

