### PR TITLE
[REF] Remove fancy maxpool

### DIFF
--- a/sklearn_theano/base.py
+++ b/sklearn_theano/base.py
@@ -306,7 +306,9 @@ if LooseVersion(theano.__version__) < LooseVersion('0.7.0'):
 else:
     def fancy_max_pool(input_tensor, pool_shape, pool_stride,
                        ignore_border=False, padding=(0, 0)):
-        return T.signal.downsample.maxpool_2d(input_tensor, pool_shape,
+        if padding not in [0, (0, 0)]:
+            ignore_border = True
+        return T.signal.downsample.max_pool_2d(input_tensor, pool_shape,
                                               ignore_border=ignore_border,
                                               st=pool_stride,
                                               padding=padding)
@@ -383,9 +385,10 @@ class CaffePool(object):
         # Replicating caffe style pooling means zero padding
         # then strided pooling with ignore_border=True
         if self.pool_type == 'max':
-            pooled = fancy_max_pool(padded_input,
+            pooled = fancy_max_pool(self.input_,
                                     self.pool_shape, self.pool_stride,
-                                    ignore_border=False)
+                                    ignore_border=False,
+                                    padding=self.padding)
         elif self.pool_type == 'avg':
             if self.padding in [0, (0, 0)]:
                 padded_input = self.input_

--- a/sklearn_theano/base.py
+++ b/sklearn_theano/base.py
@@ -9,6 +9,9 @@ import numpy as np
 import theano.tensor as T
 from theano.tensor.signal.downsample import max_pool_2d
 
+from distutils.version import LooseVersion
+import warnings
+
 
 def _relu(x):
     return T.maximum(x, 0)
@@ -240,8 +243,8 @@ def _lcm(num1, num2):
     return num1 * num2 // _gcd(num1, num2)
 
 
-def fancy_max_pool(input_tensor, pool_shape, pool_stride,
-                   ignore_border=False):
+def fancy_max_pool_(input_tensor, pool_shape, pool_stride,
+                    ignore_border=False):
     """Using theano built-in maxpooling, create a more flexible version.
 
     Obviously suboptimal, but gets the work done."""
@@ -286,6 +289,19 @@ def fancy_max_pool(input_tensor, pool_shape, pool_stride,
     return output.reshape(T.concatenate([pre_shape, output.shape[1:]]),
                           ndim=input_tensor.ndim)
 
+
+if LooseVersion(theano.__version__) < LooseVersion('0.7.0'):
+    warnings.warn(('Using theano 0.7.0 or later is recommended.'
+                   ' Current version is %s. Support for versions earlier'
+                   ' than 0.7.0 will be removed at first release.')
+                  % theano.__version__)
+    fancy_max_pool = fancy_max_pool_
+else:
+    def fancy_max_pool(input_tensor, pool_shape, pool_stride,
+                       ignore_border=False):
+        return T.signal.downsample.maxpool_2d(input_tensor, pool_shape,
+                                              ignore_border=ignore_border,
+                                              st=pool_stride)
 
 class FancyMaxPool(object):
     """Extended pooling functionality. Allows independent specification

--- a/sklearn_theano/feature_extraction/caffe/caffemodel.py
+++ b/sklearn_theano/feature_extraction/caffe/caffemodel.py
@@ -194,7 +194,7 @@ def _parse_caffe_model(caffe_model):
     return parsed
 
 
-from sklearn_theano.base import (Convolution, Relu, MaxPool, FancyMaxPool,
+from sklearn_theano.base import (Convolution, Relu, MaxPool,
                                  LRN, Feedforward, ZeroPad,
                                  CaffePool)
 

--- a/sklearn_theano/feature_extraction/caffe/tests/test_googlenet.py
+++ b/sklearn_theano/feature_extraction/caffe/tests/test_googlenet.py
@@ -1,8 +1,11 @@
 from skimage.data import coffee, camera
+from sklearn_theano.feature_extraction.caffe import googlenet
 from sklearn_theano.feature_extraction import (
     GoogLeNetTransformer, GoogLeNetClassifier)
 import numpy as np
+import theano
 from nose import SkipTest
+from numpy.testing import assert_array_almost_equal, assert_almost_equal
 import os
 
 co = coffee().astype(np.float32)
@@ -28,3 +31,45 @@ def test_googlenet_classifier():
 
     c.predict(co)
     c.predict(ca)
+
+
+def _fetch_caffe_layers_for_coffee():
+    """Loads a file containing all caffe layer outputs for
+    skimage.data.coffee."""
+
+    # TODO: write a generic pycaffe model finder
+    #       and feedforward any image or load from disk
+
+    f = np.load('coffee.npz')
+    output = dict()
+    for k in f.files:
+        output[k] = f[k]
+    return output
+
+
+def test_caffe_correspondence(verbose=1):
+    """Test correspondence of all layers to caffe model"""
+
+    c = _fetch_caffe_layers_for_coffee()
+
+    layer_expr, input_expr = googlenet.create_theano_expressions(
+        verbose=verbose)
+    layer_names = layer_expr.keys()
+
+    # restrict layers to those available in c
+    exclude = ['data']
+    layer_names = [name for name in layer_names if name in c.keys()
+                   and not name in exclude]
+
+    all_outputs = theano.function([input_expr],
+                                  [layer_expr[name] for name in layer_names])
+
+    fprop = all_outputs(c['data'][np.newaxis])
+
+    for i, name in enumerate(layer_names):
+        if verbose > 0:
+            print "Comparing %s" % name
+        assert_array_almost_equal(fprop[i][0], c[name], decimal=2)
+        assert_almost_equal(
+            ((fprop[i][0] - c[name]) ** 2).sum() / (c[name] ** 2).sum(), 0)
+


### PR DESCRIPTION
With theano maxpooling now supporting strides for a while, this removes the workaround for that for the caffemodels.

This PR supersedes "deprecate_fancy_maxpool": We do not support theano 0.6 anymore after this merge.