### PR TITLE
Added vgg caffemodel support, though no object for real use just yet

### DIFF
--- a/sklearn_theano/datasets/base.py
+++ b/sklearn_theano/datasets/base.py
@@ -26,13 +26,21 @@ def get_dataset_dir(dataset_name, data_dir=None, folder=None, create_dir=True):
     return data_dir
 
 
-def download(url, server_fname, local_fname=None, progress_update_percentage=5):
+def download(url, server_fname, local_fname=None, progress_update_percentage=5,
+             bypass_certificate_check=False):
     """
     An internet download utility modified from
     http://stackoverflow.com/questions/22676/
     how-do-i-download-a-file-over-http-using-python/22776#22776
     """
-    u = urllib.urlopen(url)
+    if bypass_certificate_check:
+        import ssl
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        u = urllib.urlopen(url, context=ctx)
+    else:
+        u = urllib.urlopen(url)
     if local_fname is None:
         local_fname = server_fname
     full_path = local_fname

--- a/sklearn_theano/feature_extraction/caffe/balanced_vgg.py
+++ b/sklearn_theano/feature_extraction/caffe/balanced_vgg.py
@@ -1,0 +1,100 @@
+"""Parser for balanced VGG caffe."""
+# Authors: Michael Eickenberg
+#          Kyle Kastner
+# License: BSD 3 Clause
+
+from sklearn.externals import joblib
+from ...datasets import get_dataset_dir, download
+from .caffemodel import _parse_caffe_model, parse_caffe_model
+import os
+import theano
+
+BALANCED_VGG_PATH = get_dataset_dir("caffe/balanced_vgg")
+
+
+def fetch_balanced_vgg_protobuffer_file(caffemodel_file=None):
+    """Checks for existence of caffemodel protobuffer.
+    Downloads it if it cannot be found."""
+
+    default_filename = os.path.join(BALANCED_VGG_PATH,
+                                    "vgg_normalised.caffemodel")
+
+    if caffemodel_file is not None:
+        if os.path.exists(caffemodel_file):
+            return caffemodel_file
+        else:
+            if os.path.exists(default_filename):
+                import warnings
+                warnings.warn('Did not find %s, but found and returned %s.' %
+                              (caffemodel_file, default_filename))
+                return default_filename
+    else:
+        if os.path.exists(default_filename):
+            return default_filename
+
+    # We didn't find the file, let's download it. To the specified location
+    # if specified, otherwise to the default place
+    if caffemodel_file is None:
+        caffemodel_file = default_filename
+        if not os.path.exists(BALANCED_VGG_PATH):
+            os.makedirs(BALANCED_VGG_PATH)
+
+    url = "https://bethgelab.org/media/uploads/deeptextures/"
+    url += "vgg_normalised.caffemodel"
+    # Need to bypass cert for bethge lab download
+    download(url, caffemodel_file, progress_update_percentage=1,
+             bypass_certificate_check=True)
+    return caffemodel_file
+
+
+def fetch_balanced_vgg_architecture(caffemodel_parsed=None,
+                                    caffemodel_protobuffer=None):
+    """Fetch a pickled version of the caffe model, represented as list of
+    dictionaries."""
+
+    default_filename = os.path.join(BALANCED_VGG_PATH, 'balanced_vgg.pickle')
+    if caffemodel_parsed is not None:
+        if os.path.exists(caffemodel_parsed):
+            return joblib.load(caffemodel_parsed)
+        else:
+            if os.path.exists(default_filename):
+                import warnings
+                warnings.warn('Did not find %s, but found %s. Loading it.' %
+                              (caffemodel_parsed, default_filename))
+                return joblib.load(default_filename)
+    else:
+        if os.path.exists(default_filename):
+            return joblib.load(default_filename)
+
+    # We didn't find the file: let's create it by parsing the protobuffer
+    protobuf_file = fetch_balanced_vgg_protobuffer_file(caffemodel_protobuffer)
+    model = _parse_caffe_model(protobuf_file)
+
+    if caffemodel_parsed is not None:
+        joblib.dump(model, caffemodel_parsed)
+    else:
+        joblib.dump(model, default_filename)
+
+    return model
+
+
+def create_theano_expressions(model=None, verbose=0):
+
+    if model is None:
+        model = fetch_balanced_vgg_architecture()
+
+    layers, blobs, inputs, params = parse_caffe_model(model, verbose=verbose)
+    data_input = inputs['data']
+    return blobs, data_input
+
+
+def _get_fprop(output_layers=('conv5_4',), model=None, verbose=0):
+
+    if model is None:
+        model = fetch_balanced_vgg_architecture(model)
+
+    expressions, input_data = create_theano_expressions(model,
+                                                        verbose=verbose)
+    to_compile = [expressions[expr] for expr in output_layers]
+
+    return theano.function([input_data], to_compile)

--- a/sklearn_theano/feature_extraction/caffe/googlenet.py
+++ b/sklearn_theano/feature_extraction/caffe/googlenet.py
@@ -86,7 +86,7 @@ def create_theano_expressions(model=None, verbose=0):
     if model is None:
         model = fetch_googlenet_architecture()
 
-    layers, blobs, inputs = parse_caffe_model(model, verbose=verbose)
+    layers, blobs, inputs, params = parse_caffe_model(model, verbose=verbose)
     data_input = inputs['data']
     return blobs, data_input
 

--- a/sklearn_theano/feature_extraction/caffe/vgg.py
+++ b/sklearn_theano/feature_extraction/caffe/vgg.py
@@ -1,0 +1,98 @@
+"""Parser for VGG caffemodel."""
+# Authors: Michael Eickenberg
+#          Kyle Kastner
+# License: BSD 3 Clause
+
+from sklearn.externals import joblib
+from ...datasets import get_dataset_dir, download
+from .caffemodel import _parse_caffe_model, parse_caffe_model
+import os
+import theano
+
+VGG_PATH = get_dataset_dir("caffe/vgg")
+
+
+def fetch_vgg_protobuffer_file(caffemodel_file=None):
+    """Checks for existence of caffemodel protobuffer.
+    Downloads it if it cannot be found."""
+
+    default_filename = os.path.join(VGG_PATH,
+                                    "VGG_ILSVRC_19_layers.caffemodel")
+
+    if caffemodel_file is not None:
+        if os.path.exists(caffemodel_file):
+            return caffemodel_file
+        else:
+            if os.path.exists(default_filename):
+                import warnings
+                warnings.warn('Did not find %s, but found and returned %s.' %
+                              (caffemodel_file, default_filename))
+                return default_filename
+    else:
+        if os.path.exists(default_filename):
+            return default_filename
+
+    # We didn't find the file, let's download it. To the specified location
+    # if specified, otherwise to the default place
+    if caffemodel_file is None:
+        caffemodel_file = default_filename
+        if not os.path.exists(VGG_PATH):
+            os.makedirs(VGG_PATH)
+
+    url = "http://www.robots.ox.ac.uk/%7Evgg/software/very_deep/caffe/"
+    url += "VGG_ILSVRC_19_layers.caffemodel"
+    download(url, caffemodel_file, progress_update_percentage=1)
+    return caffemodel_file
+
+
+def fetch_vgg_architecture(caffemodel_parsed=None, caffemodel_protobuffer=None):
+    """Fetch a pickled version of the caffe model, represented as list of
+    dictionaries."""
+
+    default_filename = os.path.join(VGG_PATH, 'vgg.pickle')
+    if caffemodel_parsed is not None:
+        if os.path.exists(caffemodel_parsed):
+            return joblib.load(caffemodel_parsed)
+        else:
+            if os.path.exists(default_filename):
+                import warnings
+                warnings.warn('Did not find %s, but found %s. Loading it.' %
+                              (caffemodel_parsed, default_filename))
+                return joblib.load(default_filename)
+    else:
+        if os.path.exists(default_filename):
+            return joblib.load(default_filename)
+
+    # We didn't find the file: let's create it by parsing the protobuffer
+    protobuf_file = fetch_vgg_protobuffer_file(caffemodel_protobuffer)
+    model = _parse_caffe_model(protobuf_file)
+
+    if caffemodel_parsed is not None:
+        joblib.dump(model, caffemodel_parsed)
+    else:
+        joblib.dump(model, default_filename)
+
+    return model
+
+
+def create_theano_expressions(model=None, verbose=0):
+
+    if model is None:
+        model = fetch_vgg_architecture()
+
+    layers, blobs, inputs, params = parse_caffe_model(
+        model, convert_fc_to_conv=False, verbose=verbose)
+    data_input = inputs['data']
+    return blobs, data_input
+
+
+def _get_fprop(output_layers=('prob',), model=None, verbose=0):
+
+    if model is None:
+        model = fetch_vgg_architecture(model)
+
+    expressions, input_data = create_theano_expressions(model,
+                                                        verbose=verbose)
+    to_compile = [expressions[expr] for expr in output_layers]
+
+    return theano.function([input_data], to_compile)


### PR DESCRIPTION
Opened PR for balanced VGG (from texture classification) and VGG

@eickenberg you probably don't have time to review right now, but this incorporates changes from both @yaoli and @erfannoury . Can either of you have a look over and see if anything is amiss? If no I might merge soon - there isn't a lot of public API added, though I did have to change the output of ```parse_caffe_model``` to return params - which is a better thing in the long run IMO.

Example script I used to validate it was working for balanced vgg

```          
from sklearn_theano.feature_extraction.caffe.balanced_vgg import _get_fprop      
from sklearn_theano.datasets import load_sample_image                            
im = load_sample_image('sloth.jpg')                                              
f = _get_fprop()                                                                 
r = f(im[None].transpose(0, 3, 1, 2))   
```